### PR TITLE
docs: add inline comment about how to do Ash action introspection

### DIFF
--- a/backend-elixir/lib/study_hall/accounts/user.ex
+++ b/backend-elixir/lib/study_hall/accounts/user.ex
@@ -81,6 +81,8 @@ defmodule StudyHall.Accounts.User do
   authentication do
     api StudyHall.Accounts
 
+    # If you ever want to do introspection at the actions this generates use,
+    # `Ash.Resource.Info.actions(StudyHall.Accounts.User)` inside an iex session.
     strategies do
       password :password do
         identity_field :email


### PR DESCRIPTION
This was something in my notebook that I wanted to have in the codebase in case I forgot.